### PR TITLE
User can specify commands where first arg matters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ To try it out:
 
 ```
 ./bin/run
+./bin/run --help
+./bin/run --include-first-argument=git --include-first-argument=spring
 ```
 
 `fc` output looks like this:

--- a/bin/run
+++ b/bin/run
@@ -3,4 +3,4 @@
 set -eo pipefail
 
 stack build
-fc -l 1 | stack exec most-used-exe
+fc -l 1 | stack exec most-used-exe -- "$@"

--- a/most-used.cabal
+++ b/most-used.cabal
@@ -16,8 +16,10 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     MostUsed
+                     , MostUsed.CLI
   build-depends:       base >= 4.7 && < 5
                      , megaparsec
+                     , optparse-applicative
   default-language:    Haskell2010
 
 executable most-used-exe

--- a/src/MostUsed.hs
+++ b/src/MostUsed.hs
@@ -1,6 +1,7 @@
 module MostUsed
     ( parseHistory
     , parseHistory'
+    , Command(..)
     , Argument(..)
     , Item(..)
     ) where
@@ -11,7 +12,9 @@ import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.String
 
-data Item = Item { command :: String, arguments :: [Argument] }
+type Command = String
+
+data Item = Item { command :: Command, arguments :: [Argument] }
             deriving (Show, Eq)
 
 data Argument = DoubleQuoted String
@@ -20,7 +23,15 @@ data Argument = DoubleQuoted String
               | Backticks String
               | CommandSubstitution String
               | ProcessSubstitution String
-              deriving (Show, Eq)
+              deriving (Eq)
+
+instance Show Argument where
+    show (DoubleQuoted s) = s
+    show (SingleQuoted s) = s
+    show (NotQuoted s) = s
+    show (Backticks s) = s
+    show (CommandSubstitution s) = s
+    show (ProcessSubstitution s) = s
 
 -- Like parseHistory, but just skips over lines that can't be parsed
 parseHistory' :: String -> [Item]

--- a/src/MostUsed/CLI.hs
+++ b/src/MostUsed/CLI.hs
@@ -1,0 +1,34 @@
+module MostUsed.CLI
+    ( parseCLI
+    , Options(..)
+    )
+    where
+
+import MostUsed
+import Data.Monoid ((<>))
+import Options.Applicative
+
+data Options = Options
+    { oIncludeFirstArgument :: [Command]
+    }
+
+parseCLI :: IO Options
+parseCLI =
+    execParser (withInfo parseOptions pHeader pDescription pFooter)
+  where
+    pHeader      = "Most Used: Find your most-used CLI commands"
+    pDescription = "Most used parses your commands and summarizes the \
+                   \most-used ones"
+    pFooter      = ""
+
+withInfo :: Parser a -> String -> String -> String -> ParserInfo a
+withInfo opts h d f =
+    info (helper <*> opts) $ header h <> progDesc d <> footer f
+
+parseOptions :: Parser Options
+parseOptions = Options <$> parseIncludeFirstArgument
+
+parseIncludeFirstArgument :: Parser [String]
+parseIncludeFirstArgument = many $ strOption $
+    long "include-first-argument"
+    <> help "Count this command with its first argument (can be specified more than once)"


### PR DESCRIPTION
For example, `git` and `spring` have interesting subcommands, and counting `git commit` is just as if not more interesting than counting just `git`.

Now users can provide `--include-first-arg=git` (and provide the option as many times as they want with different commands) and most-used will then count both `git` and `git commit`/`git status`/etc.

Note that there's still a count of the overall number of calls to plain `git`; the user will just _additionally_ get a count of git + every subcommand.