### PR TITLE
Commands separated by a pipe are counted separately

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -91,6 +91,12 @@ spec = do
                                         , CommandSubstitution "arg"]
                 parseHistory s `shouldBe` Right [result]
 
+            it "parses a line with multiple items separated by a pipe" $ do
+                let s = cmd "c1 one |c2 `two`"
+                let result = [Item "c1" [NotQuoted "one"]
+                             , Item "c2" [Backticks "two"]]
+                parseHistory s `shouldBe` Right result
+
         describe "with multiple items, each of which is on one line" $ do
             it "parses commands with a variety of arguments" $ do
                 let s1 = cmd "c1 one `tw\\no` $(arg)"


### PR DESCRIPTION
For example, take the following history item:

  echo "hello" | sed 's/hello/hi'

Previously, this would be one command, `echo`, with some pretty weird arguments.

Now most-used is smart enough to understand that the pipe separates two commands.