### PR TITLE
Users can choose to print failed parses

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ parsing history:
 You can also pass options:
 
     ./bin/run --include-first-argument=git --include-first-argument=spring
+
+To print lines that failed to parse:
+
+    ./bin/run --debug

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,13 +8,26 @@ import MostUsed.CLI
 
 main :: IO ()
 main = do
-    Options{oIncludeFirstArgument} <- parseCLI
-    stdin <- getContents
-    let stats = findMostUsed oIncludeFirstArgument $ parseHistory' stdin
-    putStr $ prettyPrint stats
+    Options{oIncludeFirstArgument, oDebug} <- parseCLI
+    stdinContents <- getContents
+    let f = if oDebug
+            then displayFailures
+            else displaySuccesses oIncludeFirstArgument
+    f stdinContents
 
-prettyPrint :: [(Int, String)] -> String
-prettyPrint stats = unlines $ map (\(n, count) -> show n ++ " " ++ count) stats
+displaySuccesses :: [Command] -> String -> IO ()
+displaySuccesses oIncludeFirstArgument s = do
+    let results = successes s
+    let stats = prettyPrint $ findMostUsed oIncludeFirstArgument $ results
+    putStr $ unlines $ stats
+
+displayFailures :: String -> IO ()
+displayFailures s = do
+    putStrLn "\n!!! The following lines could not be parsed:\n\n"
+    putStrLn $ unlines $ failures s
+
+prettyPrint :: [(Int, String)] -> [String]
+prettyPrint stats = map (\(n, count) -> show n ++ " " ++ count) stats
 
 findMostUsed :: [Command] -> [Item] -> [(Int, String)]
 findMostUsed includeFirstArgument items = reverseSort $

--- a/src/MostUsed.hs
+++ b/src/MostUsed.hs
@@ -1,28 +1,25 @@
 module MostUsed
-    ( parseHistory
-    , parseHistory'
+    ( successes
+    , failures
     , module MostUsed.Types
     ) where
 
+import Data.Bifunctor
 import Data.Char (isSpace, isPrint)
-import Data.Either (rights)
+import Data.Either (lefts, rights)
 import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.String
 
--- Like parseHistory, but just skips over lines that can't be parsed
-parseHistory' :: String -> [Item]
-parseHistory' s = concat $ rights $ map (parse items "(unknown)") $ lines s
+successes :: String -> [Item]
+successes = mconcat . rights . successesAndFailures . lines
 
-parseHistory :: String -> Either String [Item]
-parseHistory s = concat <$> history (lines s)
+failures :: String -> [String]
+failures = lefts . successesAndFailures . lines
 
-history :: [String] -> Either String [[Item]]
-history (s:ss) = case parse items "(unknown)" s of
-                   (Left err) -> Left $ parseErrorPretty err
-                   (Right x) -> (:) <$> Right x <*> history ss
-history [] = Right []
+successesAndFailures :: [String] -> [Either String [Item]]
+successesAndFailures = map (\s -> first parseErrorPretty $ parse items s s)
 
 items :: Parser [Item]
 items = do

--- a/src/MostUsed/CLI.hs
+++ b/src/MostUsed/CLI.hs
@@ -10,6 +10,7 @@ import Options.Applicative
 
 data Options = Options
     { oIncludeFirstArgument :: [Command]
+    , oDebug :: Bool
     }
 
 parseCLI :: IO Options
@@ -26,9 +27,14 @@ withInfo opts h d f =
     info (helper <*> opts) $ header h <> progDesc d <> footer f
 
 parseOptions :: Parser Options
-parseOptions = Options <$> parseIncludeFirstArgument
+parseOptions = Options <$> parseIncludeFirstArgument <*> parseDebug
 
 parseIncludeFirstArgument :: Parser [String]
 parseIncludeFirstArgument = many $ strOption $
     long "include-first-argument"
     <> help "Count this command with its first argument (can be specified more than once)"
+
+parseDebug :: Parser Bool
+parseDebug = switch $
+    long "debug"
+    <> help "Print only lines that couldn't be parsed"


### PR DESCRIPTION
By default most-used will only print successfully parsed lines.

Now, when passed the `--debug` option, it will print errors about unparsable lines.