### PR TITLE
Parse Bash history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # most-used
 
-This takes input from Zsh's `fc` command and parses it to find your most-used
-commands.
+This will find your most-used shell commands. It automatically detects whether
+you're using Zsh or Bash and prints out the history for the correct shell.
 
 To try it out:
 
@@ -16,12 +16,16 @@ $ most-used | head
 After changing something, you can run this to recompile and see the result of
 parsing history:
 
-    ./bin/run
+    ./bin/run-zsh
+
+Or, to parse your Bash history:
+
+    ./bin/run-bash
 
 You can also pass options:
 
-    ./bin/run --include-first-argument=git --include-first-argument=spring
+    ./bin/run-zsh --include-first-argument=git --include-first-argument=spring
 
 To print lines that failed to parse:
 
-    ./bin/run --debug
+    ./bin/run-zsh --debug

--- a/bin/most-used
+++ b/bin/most-used
@@ -1,5 +1,13 @@
-#!/usr/bin/env zsh -i
+#!/bin/sh
 
-set -eo pipefail
+myshell=${SHELL:-zsh}
 
-fc -l 1 | most-used-exe "$@"
+case "$myshell" in
+  *bash) most-used-bash "$@";;
+  *zsh) most-used-zsh "$@";;
+  *)
+    echo "Your shell, $myshell, is not supported."
+    echo "most-used only supports Zsh and Bash (for now)."
+    exit 1
+    ;;
+esac

--- a/bin/most-used-bash
+++ b/bin/most-used-bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eo pipefail
+
+cat "${HISTFILE:-"$HOME/.bash_history"}" | most-used-exe --shell bash "$@"

--- a/bin/most-used-zsh
+++ b/bin/most-used-zsh
@@ -1,0 +1,11 @@
+#!/usr/bin/env zsh -i --no-globalrcs --no-rcs
+
+set -eo pipefail
+
+# Zsh doesn't have this set by default, but its startup wizard sets it to
+# `$HOME/.zsh_history`. It's a fine guess to use since we're not loading any
+# startup rc files. Maybe later this will become a problem and require removing
+# the `--no-globalrcs --no-rcs` flags.
+HISTFILE=${HISTFILE:-$HOME/.zsh_history}
+
+fc -l 1 | most-used-exe --shell zsh "$@"

--- a/bin/run
+++ b/bin/run
@@ -1,6 +1,0 @@
-#!/usr/bin/env zsh -i
-
-set -eo pipefail
-
-stack build
-fc -l 1 | stack exec most-used-exe -- "$@"

--- a/bin/run-bash
+++ b/bin/run-bash
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eo pipefail
+
+stack build
+stack install 2>/dev/null
+PATH=$HOME/.local/bin:$PATH ./bin/most-used-bash "$@"

--- a/bin/run-zsh
+++ b/bin/run-zsh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eo pipefail
+
+stack build
+stack install 2>/dev/null
+PATH=$HOME/.local/bin:$PATH ./bin/most-used-zsh "$@"

--- a/most-used.cabal
+++ b/most-used.cabal
@@ -17,6 +17,8 @@ library
   hs-source-dirs:      src
   exposed-modules:     MostUsed
                      , MostUsed.CLI
+                     , MostUsed.Parser.Bash
+                     , MostUsed.Parser.Common
                      , MostUsed.Parser.Zsh
                      , MostUsed.Types
   build-depends:       base >= 4.7 && < 5
@@ -30,6 +32,7 @@ executable most-used-exe
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , most-used
+                     , megaparsec == 5.2.0
   default-language:    Haskell2010
 
 test-suite spec
@@ -40,8 +43,9 @@ test-suite spec
   ghc-options: -Wall
   build-depends:
       base == 4.*
-    , most-used
     , hspec == 2.*
+    , megaparsec == 5.2.0
+    , most-used
   other-modules: MostUsed.MostUsedSpec
   default-language: Haskell2010
 

--- a/src/MostUsed/CLI.hs
+++ b/src/MostUsed/CLI.hs
@@ -11,6 +11,7 @@ import Options.Applicative
 data Options = Options
     { oIncludeFirstArgument :: [Command]
     , oDebug :: Bool
+    , oShell :: Shell
     }
 
 parseCLI :: IO Options
@@ -27,12 +28,27 @@ withInfo opts h d f =
     info (helper <*> opts) $ header h <> progDesc d <> footer f
 
 parseOptions :: Parser Options
-parseOptions = Options <$> parseIncludeFirstArgument <*> parseDebug
+parseOptions = Options
+    <$> parseIncludeFirstArgument
+    <*> parseDebug
+    <*> parseShell
 
 parseIncludeFirstArgument :: Parser [String]
 parseIncludeFirstArgument = many $ strOption $
     long "include-first-argument"
+    <> metavar "command_name"
     <> help "Count this command with its first argument (can be specified more than once)"
+
+parseShell :: Parser Shell
+parseShell = fmap shell $ strOption $
+    long "shell"
+    <> metavar "[bash | zsh]"
+    <> help "Which type of shell history to parse"
+
+shell :: String -> Shell
+shell "bash" = Bash
+shell "zsh" = Zsh
+shell _ = error "--shell can only take 'bash' or 'zsh'"
 
 parseDebug :: Parser Bool
 parseDebug = switch $

--- a/src/MostUsed/Parser/Bash.hs
+++ b/src/MostUsed/Parser/Bash.hs
@@ -1,4 +1,4 @@
-module MostUsed.Parser.Zsh
+module MostUsed.Parser.Bash
     ( items
     ) where
 
@@ -8,8 +8,4 @@ import Text.Megaparsec
 import Text.Megaparsec.String
 
 items :: Parser [Item]
-items = do
-    some spaceChar
-    some digitChar -- history number
-    string "  "
-    item `sepBy` pipe <* eof
+items = item `sepBy` pipe <* eof

--- a/src/MostUsed/Parser/Common.hs
+++ b/src/MostUsed/Parser/Common.hs
@@ -1,0 +1,48 @@
+module MostUsed.Parser.Common
+    ( item
+    , pipe
+    ) where
+
+import Data.Char (isSpace, isPrint)
+import MostUsed.Types
+import Text.Megaparsec
+import Text.Megaparsec.String
+
+item :: Parser Item
+item = do
+    command <- some allowedCharsInBareWords
+    space
+    arguments <- singleArgument `sepEndBy` separator
+    return $ Item command arguments
+
+pipe :: Parser ()
+pipe = space >> char '|' >> space
+
+separator :: Parser [String]
+separator = some (try escapedNewline <|> some spaceChar)
+
+singleArgument :: Parser Argument
+singleArgument =
+    DoubleQuoted <$> surroundedBy "\""
+    <|> SingleQuoted <$> surroundedBy "'"
+    <|> Backticks <$> surroundedBy "`"
+    <|> CommandSubstitution <$> try (char '$' *> surroundedByParens)
+    <|> ProcessSubstitution <$> (char '<' *> surroundedByParens)
+    <|> SingleQuoted <$> try (char '$' *> surroundedBy "'")
+    <|> NotQuoted <$> some allowedCharsInBareWords
+    <?> "single argument parser"
+
+allowedCharsInBareWords :: Parser Char
+allowedCharsInBareWords = satisfy (\c ->
+    c /= '|' && not (isSpace c) && isPrint c)
+
+surroundedBy :: String -> Parser String
+surroundedBy s = between (string s) (string s) (many $ noneOf s)
+    <?> ("surrounded by " ++ s)
+
+surroundedByParens :: Parser String
+surroundedByParens = between (char '(') (char ')') (many $ noneOf "()")
+    <?> "surrounded by parentheses"
+
+escapedNewline :: Parser String
+escapedNewline = string "\\n"

--- a/src/MostUsed/Types.hs
+++ b/src/MostUsed/Types.hs
@@ -2,9 +2,12 @@ module MostUsed.Types
     ( Command(..)
     , Argument(..)
     , Item(..)
+    , Shell(..)
     ) where
 
 type Command = String
+
+data Shell = Zsh | Bash
 
 data Item = Item { command :: Command, arguments :: [Argument] }
             deriving (Show, Eq)

--- a/test/MostUsed/MostUsedSpec.hs
+++ b/test/MostUsed/MostUsedSpec.hs
@@ -5,94 +5,82 @@ module MostUsed.MostUsedSpec
 
 import Data.List (intercalate)
 import MostUsed
+import MostUsed.Parser.Bash as Bash
 import MostUsed.Parser.Zsh as Zsh
 import Test.Hspec
-
-commandNumber :: String
-commandNumber = "  452  "
-
-unparseableCommand :: String
-unparseableCommand = cmd "foo(){\\n # -X = \"whatever\", blah\\n"
-
-cmd :: String -> String
-cmd s = commandNumber ++ s
-
-cmd2 :: String -> String
-cmd2 s = "    1  " ++ s
+import Text.Megaparsec.String
 
 main :: IO ()
 main = hspec spec
 
-escapedNewline :: String
-escapedNewline = "\\n"
-
 spec :: Spec
-spec = do
+spec = describe "top level" $ do
+    commonSpec "Bash parser" Bash.items bashCommand
+    commonSpec "Zsh parser" Zsh.items zshCommand
+    zshSpec Zsh.items zshCommand
+
+commonSpec :: String -> Parser [Item] -> (String -> String) -> Spec
+commonSpec description parser cmd = describe description $ do
     describe "failures" $ do
         it "returns a pretty error message" $ do
-            let s = "bad"
-            failures Zsh.items s `shouldBe` ["bad:1:1:\nunexpected 'b'\nexpecting white space\n"]
+            let s = "||||"
+            head (failures parser s) `shouldStartWith` "||||:1:1"
 
         it "does not return any successfully parsed commands" $ do
             let s = cmd "cmd 'a'"
-            failures Zsh.items s `shouldBe` []
+            failures parser s `shouldBe` []
 
     describe "successes" $ do
         it "ignores a single unparseable command" $ do
-            successes Zsh.items unparseableCommand `shouldBe` []
+            successes parser (unparseableCommand cmd) `shouldBe` []
 
         it "ignores an unparseable command but parses the good one" $ do
-            let s1 = unparseableCommand
+            let s1 = unparseableCommand cmd
             let s2 = cmd "cmd 'a'"
             let s = intercalate "\n" [s1, s2]
-            successes Zsh.items s `shouldBe` [Item "cmd" [SingleQuoted "a"]]
+            successes parser s `shouldBe` [Item "cmd" [SingleQuoted "a"]]
 
         describe "with a single item" $ do
             it "parses a command with no arguments" $ do
                 let s = cmd "cmd"
                 let result = Item "cmd" []
-                successes Zsh.items s `shouldBe` [result]
-
-            it "parses a command with no arguments and a low number" $ do
-                let s = cmd2 "cmd"
-                let result = Item "cmd" []
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command with one unquoted argument" $ do
                 let s = cmd "cmd arg"
                 let result = Item "cmd" [NotQuoted "arg"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command with one single-quoted argument" $ do
                 let s = cmd "cmd 'a r g'"
                 let result = Item "cmd" [SingleQuoted "a r g"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command with one double-quoted argument" $ do
                 let s = cmd "cmd \"a r g\""
                 let result = Item "cmd" [DoubleQuoted "a r g"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command with one backtick-ed argument" $ do
                 let s = cmd "cmd `arg`"
                 let result = Item "cmd" [Backticks "arg"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command with one $(argument)" $ do
                 let s = cmd "cmd $(arg x)"
                 let result = Item "cmd" [CommandSubstitution "arg x"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command preceded by a backslash" $ do
                 let s = cmd "\\psql arg"
                 let result = Item "\\psql" [NotQuoted "arg"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command with process substitution" $ do
                 let s = cmd "cmd <(one) <(two)"
                 let result = Item "cmd" [ProcessSubstitution "one"
                                         , ProcessSubstitution "two"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a command with a variety of arguments" $ do
                 let s = cmd "cmd one `two` '3 x' \"4 y\" $(arg)"
@@ -101,31 +89,64 @@ spec = do
                                         , SingleQuoted "3 x"
                                         , DoubleQuoted "4 y"
                                         , CommandSubstitution "arg"]
-                successes Zsh.items s `shouldBe` [result]
+                successes parser s `shouldBe` [result]
 
             it "parses a line with multiple items separated by a pipe" $ do
                 let s = cmd "c1 one |c2 `two`"
                 let result = [Item "c1" [NotQuoted "one"]
                              , Item "c2" [Backticks "two"]]
-                successes Zsh.items s `shouldBe` result
+                successes parser s `shouldBe` result
 
             it "parses a line with @" $ do
                 let s = cmd "echo @gabebw"
                 let result = [Item "echo" [NotQuoted "@gabebw"]]
 
-                successes Zsh.items s `shouldBe` result
+                successes parser s `shouldBe` result
 
             it "parses a line with $-quoting" $ do
                 let s = cmd "echo $' hello '"
                 let result = [Item "echo" [SingleQuoted " hello "]]
 
-                successes Zsh.items s `shouldBe` result
+                successes parser s `shouldBe` result
 
             it "parses a line with a variable" $ do
                 let s = cmd "echo $var"
                 let result = [Item "echo" [NotQuoted "$var"]]
 
-                successes Zsh.items s `shouldBe` result
+                successes parser s `shouldBe` result
+
+        describe "with multiple items, each of which is on one line" $ do
+            it "parses commands with a variety of arguments" $ do
+                let s1 = cmd "c1 one `two` $(arg)"
+                let s2 = cmd "c2 '3 x' \"4 y\""
+                let s3 = cmd "c3"
+                let s = intercalate "\n" [s1, s2, s3]
+                let i1 = Item "c1" [NotQuoted "one"
+                                   , Backticks "two"
+                                   , CommandSubstitution "arg"]
+                let i2 = Item "c2" [SingleQuoted "3 x"
+                                   , DoubleQuoted "4 y"]
+                successes parser s `shouldBe` [i1, i2, Item "c3" []]
+
+        it "can parse something with a bare escaped newline" $ do
+            let s = cmd "fc -lDt 1 \\n"
+            let item = Item "fc" [NotQuoted "-lDt", NotQuoted "1"]
+
+            successes parser s `shouldBe` [item]
+
+zshSpec :: Parser [Item] -> (String -> String) -> Spec
+zshSpec parser cmd = describe "Zsh-only tests" $ do
+    describe "failures" $ do
+        it "does not parse a string without a command number" $ do
+            let s = "no-number"
+            head (failures parser s) `shouldStartWith` "no-number:1:1"
+
+    describe "successes" $ do
+        describe "with a single item" $ do
+            it "parses a command with no arguments and a low number" $ do
+                let s = zshCommandWithLowNumber "cmd"
+                let result = Item "cmd" []
+                successes parser s `shouldBe` [result]
 
         describe "with multiple items, each of which is on one line" $ do
             it "parses commands with a variety of arguments" $ do
@@ -138,13 +159,13 @@ spec = do
                                    , CommandSubstitution "arg"]
                 let i2 = Item "c2" [SingleQuoted "3 x"
                                    , DoubleQuoted "4 y"]
-                successes Zsh.items s `shouldBe` [i1, i2, Item "c3" []]
+                successes parser s `shouldBe` [i1, i2, Item "c3" []]
 
         it "can parse something with a bare escaped newline" $ do
             let s = cmd "fc -lDt 1 \\n"
             let item = Item "fc" [NotQuoted "-lDt", NotQuoted "1"]
 
-            successes Zsh.items s `shouldBe` [item]
+            successes parser s `shouldBe` [item]
 
         describe "with multiple items, not all of which are on one line" $ do
             it "parses commands with a variety of arguments" $ do
@@ -157,4 +178,21 @@ spec = do
                                    , CommandSubstitution "arg"]
                 let i2 = Item "c2" [SingleQuoted "3\\n x"
                                    , DoubleQuoted "4 \\ny"]
-                successes Zsh.items s `shouldBe` [i1, i2, Item "c3" []]
+                successes parser s `shouldBe` [i1, i2, Item "c3" []]
+
+escapedNewline :: String
+escapedNewline = "\\n"
+
+unparseableCommand :: (String -> String) -> String
+unparseableCommand cmd = cmd "foo(){\\n # -X = \"whatever\", blah\\n"
+
+bashCommand :: String -> String
+bashCommand = id
+
+zshCommand :: String -> String
+zshCommand s = commandNumber ++ s
+    where
+        commandNumber = "  452  "
+
+zshCommandWithLowNumber :: String -> String
+zshCommandWithLowNumber s = "    1  " ++ s


### PR DESCRIPTION
Plus, the common parser code is now smart enough to know that pipes can't be part of a command.