### PR TITLE
Rename Item to Command

### DIFF
--- a/src/MostUsed.hs
+++ b/src/MostUsed.hs
@@ -10,11 +10,11 @@ import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.String
 
-successes :: Parser [Item] -> String -> [Item]
+successes :: Parser [Command] -> String -> [Command]
 successes parser s = mconcat $ rights $ successesAndFailures parser $ lines s
 
-failures :: Parser [Item] -> String -> [String]
+failures :: Parser [Command] -> String -> [String]
 failures parser s = lefts $ successesAndFailures parser $ lines s
 
-successesAndFailures :: Parser [Item] -> [String] -> [Either String [Item]]
+successesAndFailures :: Parser [Command] -> [String] -> [Either String [Command]]
 successesAndFailures parser = map (\s -> first parseErrorPretty $ parse parser s s)

--- a/src/MostUsed/CLI.hs
+++ b/src/MostUsed/CLI.hs
@@ -9,7 +9,7 @@ import MostUsed
 import Options.Applicative
 
 data Options = Options
-    { oIncludeFirstArgument :: [Command]
+    { oIncludeFirstArgument :: [CommandName]
     , oDebug :: Bool
     , oShell :: Shell
     }
@@ -33,7 +33,7 @@ parseOptions = Options
     <*> parseDebug
     <*> parseShell
 
-parseIncludeFirstArgument :: Parser [String]
+parseIncludeFirstArgument :: Parser [CommandName]
 parseIncludeFirstArgument = many $ strOption $
     long "include-first-argument"
     <> metavar "command_name"

--- a/src/MostUsed/Parser/Bash.hs
+++ b/src/MostUsed/Parser/Bash.hs
@@ -7,5 +7,5 @@ import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.String
 
-items :: Parser [Item]
+items :: Parser [Command]
 items = item `sepBy` pipe <* eof

--- a/src/MostUsed/Parser/Common.hs
+++ b/src/MostUsed/Parser/Common.hs
@@ -8,12 +8,12 @@ import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.String
 
-item :: Parser Item
+item :: Parser Command
 item = do
-    command <- some allowedCharsInBareWords
+    commandName <- some allowedCharsInBareWords
     space
     arguments <- singleArgument `sepEndBy` separator
-    return $ Item command arguments
+    return $ Command commandName arguments
 
 pipe :: Parser ()
 pipe = space >> char '|' >> space

--- a/src/MostUsed/Parser/Zsh.hs
+++ b/src/MostUsed/Parser/Zsh.hs
@@ -7,7 +7,7 @@ import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.String
 
-items :: Parser [Item]
+items :: Parser [Command]
 items = do
     some spaceChar
     some digitChar -- history number

--- a/src/MostUsed/Types.hs
+++ b/src/MostUsed/Types.hs
@@ -1,15 +1,15 @@
 module MostUsed.Types
-    ( Command(..)
+    ( CommandName(..)
     , Argument(..)
-    , Item(..)
+    , Command(..)
     , Shell(..)
     ) where
 
-type Command = String
+type CommandName = String
 
 data Shell = Zsh | Bash
 
-data Item = Item { command :: Command, arguments :: [Argument] }
+data Command = Command { commandName :: CommandName, arguments :: [Argument] }
             deriving (Show, Eq)
 
 data Argument = DoubleQuoted String


### PR DESCRIPTION
`Item` meant "one item in the history", but now there can be multiple
Items from one line of history (e.g. with pipes, and possibly in the
future with command substitution).

It makes more sense to call these Commands.

Fixes #12