### PR TITLE
Set necessary environment variables for Zsh history

### DIFF
--- a/bin/most-used-zsh
+++ b/bin/most-used-zsh
@@ -1,11 +1,9 @@
-#!/usr/bin/env zsh -i --no-globalrcs --no-rcs
+#!/usr/bin/env zsh -i
 
 set -eo pipefail
 
-# Zsh doesn't have this set by default, but its startup wizard sets it to
-# `$HOME/.zsh_history`. It's a fine guess to use since we're not loading any
-# startup rc files. Maybe later this will become a problem and require removing
-# the `--no-globalrcs --no-rcs` flags.
 HISTFILE=${HISTFILE:-$HOME/.zsh_history}
+HISTSIZE=1000000000000000000
+fc -R "$HISTFILE"
 
 fc -l 1 | most-used-exe --shell zsh "$@"

--- a/bin/run-zsh
+++ b/bin/run-zsh
@@ -1,7 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env zsh -i
 
 set -eo pipefail
 
 stack build
-stack install 2>/dev/null
-PATH=$HOME/.local/bin:$PATH ./bin/most-used-zsh "$@"
+
+HISTFILE=${HISTFILE:-$HOME/.zsh_history}
+HISTSIZE=1000000000000000000
+fc -R "$HISTFILE"
+
+fc -l 1 | stack exec most-used-exe -- --shell zsh "$@"


### PR DESCRIPTION
Zsh doesn't have `$HISTFILE` set by default, but its startup wizard sets it to `$HOME/.zsh_history`. Thus, default it to `$HOME/.zsh_history` since we're not loading any startup files. Someone could set `$HISTFILE` to something else, but for now I don't want to load any RC files.

Both `$HISTFILE` and `$HISTSIZE` must be set, otherwise `fc` only prints commands from the present session. Set `$HISTSIZE` to something huge so it gets all of the entries, then load the history events with `fc -R`.

Remove the `--no-globalrcs --no-rcs` flag so that Zsh knows about custom `$HISTFILE` settings. However, this also means that (at least on my machine) Zsh puts the path to the Homebrew-installed `most-used-exe` first, and so it doesn't see the local `most-used-exe`. So, just copy
over the commands from `most-used-zsh` to `run-zsh`. It's not very DRY, but it's guaranteed to work.
