### PR TITLE
Use Data.HashMap instead of a list of tuples

### DIFF
--- a/most-used.cabal
+++ b/most-used.cabal
@@ -34,6 +34,7 @@ executable most-used-exe
   build-depends:       base
                      , most-used
                      , megaparsec == 5.2.0
+                     , unordered-containers == 0.2.8.0
   default-language:    Haskell2010
 
 test-suite spec


### PR DESCRIPTION
Advantages:

* The Map is a real data structure and has straightforward operations like "add 1 to the value for this key"
* No need for weird stuff like `toTuple [] = (0, "unknown")`; all commands are either in the Map or not

Disadvantage:

* I wish I could use `Data.Map.toDescList` from the `containers` (_not_ `unordered-containers`) package but that sorts by _key_, and all of the keys are the command names, not the count. This is because the counts are not unique (e.g. there are many commands with a count of 1) and so can't be used in the map. So instead, it's stored as an unordered map that is then converted to a list in order to be sorted by value.

Fixes #15.