### PR TITLE
ProcessSubstitution now contains a Command

### DIFF
--- a/src/MostUsed/Parser/Common.hs
+++ b/src/MostUsed/Parser/Common.hs
@@ -26,9 +26,9 @@ singleArgument =
     DoubleQuoted <$> surroundedBy "\""
     <|> SingleQuoted <$> surroundedBy "'"
     <|> Backticks <$> surroundedBy "`"
-    <|> CommandSubstitution <$> try (string "$(" *> item <* char ')')
+    <|> CommandSubstitution <$> try (char '$' *> surroundedByParens item)
     <|> Heredoc <$> try (string "<<<" *> heredocBody)
-    <|> ProcessSubstitution <$> (char '<' *> surroundedByParens)
+    <|> ProcessSubstitution <$> (char '<' *> surroundedByParens item)
     <|> SingleQuoted <$> try (char '$' *> surroundedBy "'")
     <|> NotQuoted <$> bareWord
     <?> "single argument parser"
@@ -48,8 +48,8 @@ surroundedBy :: String -> Parser String
 surroundedBy s = between (string s) (string s) (many $ noneOf s)
     <?> ("surrounded by " ++ s)
 
-surroundedByParens :: Parser String
-surroundedByParens = between (char '(') (char ')') (many $ noneOf "()")
+surroundedByParens :: Parser a -> Parser a
+surroundedByParens p = char '(' *> p <* char ')'
     <?> "surrounded by parentheses"
 
 escapedNewline :: Parser String

--- a/src/MostUsed/Types.hs
+++ b/src/MostUsed/Types.hs
@@ -17,7 +17,7 @@ data Argument = DoubleQuoted String
               | NotQuoted String
               | Backticks String
               | CommandSubstitution Command
-              | ProcessSubstitution String
+              | ProcessSubstitution Command
               | Heredoc String
               deriving (Eq)
 
@@ -27,5 +27,5 @@ instance Show Argument where
     show (NotQuoted s) = s
     show (Backticks s) = "`" ++ s ++ "`"
     show (CommandSubstitution c) = "$(" ++ show c ++ ")"
-    show (ProcessSubstitution s) = "<(" ++ s ++ ")"
+    show (ProcessSubstitution c) = "<(" ++ show c ++ ")"
     show (Heredoc s) = "<<<'" ++ s ++ "'"

--- a/test/MostUsed/MostUsedSpec.hs
+++ b/test/MostUsed/MostUsedSpec.hs
@@ -86,9 +86,10 @@ commonSpec description parser cmd = describe description $ do
                 successes parser s `shouldBe` [result]
 
             it "parses a command with process substitution" $ do
-                let s = cmd "cmd <(one) <(two)"
-                let result = Command "cmd" [ProcessSubstitution "one"
-                                        , ProcessSubstitution "two"]
+                let s = cmd "cmd <(one 'a') <(two)"
+                let one = Command "one" [SingleQuoted "a"]
+                let two = Command "two" []
+                let result = Command "cmd" (map ProcessSubstitution [one, two])
                 successes parser s `shouldBe` [result]
 
             it "parses a command with a variety of arguments" $ do


### PR DESCRIPTION
Previously it contained an unparsed `String`, but now (like `CommandSubstitution`) it contains a `Command`.