### PR TITLE
Commands can be separated by semicolons now

### DIFF
--- a/src/MostUsed/Parser/Bash.hs
+++ b/src/MostUsed/Parser/Bash.hs
@@ -2,10 +2,10 @@ module MostUsed.Parser.Bash
     ( items
     ) where
 
-import MostUsed.Parser.Common
+import qualified MostUsed.Parser.Common as Common (items)
 import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.String
 
 items :: Parser [Command]
-items = item `sepBy` pipe <* eof
+items = Common.items

--- a/src/MostUsed/Parser/Common.hs
+++ b/src/MostUsed/Parser/Common.hs
@@ -1,12 +1,19 @@
 module MostUsed.Parser.Common
-    ( item
-    , pipe
+    ( items
     ) where
 
+import Control.Applicative (Alternative(..))
 import Data.Char (isSpace, isPrint)
 import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.String
+
+items :: Parser [Command]
+items = item `sepByAnyOf` commandSeparators <* eof
+
+-- This is exactly like `sepBy`, but with multiple possible separators.
+sepByAnyOf :: Alternative m => m a -> [m b] -> m [a]
+sepByAnyOf p seps = (:) <$> p <*> many (choice (map (*> p) seps))
 
 item :: Parser Command
 item = do
@@ -14,6 +21,12 @@ item = do
     space
     args <- singleArgument `sepEndBy` separator
     return $ Command name args
+
+commandSeparators :: [Parser ()]
+commandSeparators = [pipe, semicolon]
+
+semicolon :: Parser ()
+semicolon = space >> char ';' >> space
 
 pipe :: Parser ()
 pipe = space >> char '|' >> space

--- a/src/MostUsed/Parser/Zsh.hs
+++ b/src/MostUsed/Parser/Zsh.hs
@@ -3,7 +3,7 @@ module MostUsed.Parser.Zsh
     ) where
 
 import Control.Monad (void)
-import MostUsed.Parser.Common
+import qualified MostUsed.Parser.Common as Common (items)
 import MostUsed.Types
 import Text.Megaparsec
 import Text.Megaparsec.String
@@ -13,4 +13,4 @@ items = do
     void $ some spaceChar
     void $ some digitChar -- history number
     void $ string "  "
-    item `sepBy` pipe <* eof
+    Common.items

--- a/test/MostUsed/MostUsedSpec.hs
+++ b/test/MostUsed/MostUsedSpec.hs
@@ -143,18 +143,35 @@ commonSpec description parser cmd = describe description $ do
 
                 successes parser s `shouldBe` [result]
 
-        describe "with multiple items, each of which is on one line" $ do
-            it "parses commands with a variety of arguments" $ do
-                let s1 = cmd "c1 one `two` $(arg)"
-                let s2 = cmd "c2 '3 x' \"4 y\""
-                let s3 = cmd "c3"
-                let s = intercalate "\n" [s1, s2, s3]
-                let i1 = Command "c1" [NotQuoted "one"
-                                   , Backticks "two"
-                                   , CommandSubstitution (Command "arg" [])]
-                let i2 = Command "c2" [SingleQuoted "3 x"
-                                   , DoubleQuoted "4 y"]
-                successes parser s `shouldBe` [i1, i2, Command "c3" []]
+        describe "with multiple items" $ do
+            describe "each of which is on its own line" $ do
+                it "parses commands with a variety of arguments" $ do
+                    let s1 = cmd "c1 one `two` $(arg)"
+                    let s2 = cmd "c2 '3 x' \"4 y\""
+                    let s3 = cmd "c3"
+                    let s = intercalate "\n" [s1, s2, s3]
+                    let i1 = Command "c1" [NotQuoted "one"
+                                    , Backticks "two"
+                                    , CommandSubstitution (Command "arg" [])]
+                    let i2 = Command "c2" [SingleQuoted "3 x"
+                                    , DoubleQuoted "4 y"]
+                    successes parser s `shouldBe` [i1, i2, Command "c3" []]
+
+            describe "separated by a semicolon" $ do
+                it "parses commands with a variety of arguments" $ do
+                    let s1 = "c1 one `two` $(arg)"
+                    let s2 = "c2 '3 x' \"4 y\""
+                    let s3 = "c3"
+                    -- Note that there's only one `cmd` prefix, since Zsh only
+                    -- adds the prefix for items on a new line, and these items
+                    -- are all on the same line.
+                    let s = cmd $ intercalate ";" [s1, s2, s3]
+                    let i1 = Command "c1" [NotQuoted "one"
+                                    , Backticks "two"
+                                    , CommandSubstitution (Command "arg" [])]
+                    let i2 = Command "c2" [SingleQuoted "3 x"
+                                    , DoubleQuoted "4 y"]
+                    successes parser s `shouldBe` [i1, i2, Command "c3" []]
 
         it "can parse something with a bare escaped newline" $ do
             let s = cmd "fc -lDt 1 \\n"


### PR DESCRIPTION
Previously, they could only be separated by pipes.

Now they can be separated by pipes _or_ semicolons.

While I'm in the code, I also cleaned up `Common.items` to do more of the common work so that `Zsh` and `Bash` don't have to reimplement as much of what should be common code.

Fixes #34.